### PR TITLE
fix: change brewing permission default to TRUE

### DIFF
--- a/common/src/main/java/org/aincraft/internal/PotionTrieFactory.java
+++ b/common/src/main/java/org/aincraft/internal/PotionTrieFactory.java
@@ -122,7 +122,7 @@ final class PotionTrieFactory {
         nodeSection.getInt("amount", 1));
     @NotNull String permissionString =
         "alchemica." + nodeSection.getName().toLowerCase(Locale.ENGLISH);
-    Bukkit.getPluginManager().addPermission(new Permission(permissionString, PermissionDefault.OP));
+    Bukkit.getPluginManager().addPermission(new Permission(permissionString, PermissionDefault.TRUE));
     return new Node(nodeType,
         ingredient,
         consumer, permissionString);


### PR DESCRIPTION
## Summary

Fixes #1 - Players unable to extract brewed potions, getting water bottles instead.

## Root Cause

The brewing permissions in `PotionTrieFactory.java` were registered with `PermissionDefault.OP`, meaning only server operators could brew potions by default.

## The Bug Flow

1. Non-OP player adds ingredients to cauldron ✓
2. Player stirs with stick/blaze rod
3. Trie search checks permission → fails with `NO_PERMISSION`
4. Cauldron is **removed** from DAO (as per stir failure handling)
5. Player uses glass bottle on cauldron
6. Cauldron not found in DAO → event not cancelled
7. Vanilla behavior: water bottle given instead of brewed potion

## Fix

Changed `PermissionDefault.OP` to `PermissionDefault.TRUE` so all players have brewing permissions by default.

## Testing

- Verified the code path in `CauldronListener.java` that removes cauldron on stir failure
- Verified the trie search permission check in `Trie.java`
- Confirmed `PermissionDefault.TRUE` grants permission to all players by default

Fixes mintychochip/Alchemica#1